### PR TITLE
remove the @enhance/sandbox changed to @architect/sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ curl -L https://github.com/enhance-dev/enhance-ssr-wasm/releases/download/v0.0.3
 ## Run 
 Launch the development server with:
 ```sh
-npx @enhance/sandbox
+npx npx @architect/sandbox
 ```

--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ curl -L https://github.com/enhance-dev/enhance-ssr-wasm/releases/download/v0.0.3
 ## Run 
 Launch the development server with:
 ```sh
-npx npx @architect/sandbox
+npx @architect/sandbox
 ```


### PR DESCRIPTION
### Issue
```sh 
npx @enhance/sandbox
```
![followDocs](https://github.com/enhance-dev/enhance-ssr-python/assets/99230888/e4b09709-33f6-4261-85e1-2a164c281591)


package does not exit in npm which causing Error

### Solution
an Architect (a toolchain for deploying to AWS - which powers a lot of Enhance) project. Architect projects can be in Python. 
```sh
npx @architect/sandbox
```

